### PR TITLE
disk Generate() do import replacement on GoPaths before SrcDirs

### DIFF
--- a/v2/jam/parser/prospect.go
+++ b/v2/jam/parser/prospect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gobuffalo/packr/v2/plog"
 )
 
-var DefaultIgnoredFolders = []string{".", "_", "vendor", "node_modules", "_fixtures"}
+var DefaultIgnoredFolders = []string{".", "_", "vendor", "node_modules", "_fixtures", "testdata"}
 
 func IsProspect(path string, ignore ...string) (status bool) {
 	// plog.Debug("parser", "IsProspect", "path", path, "ignore", ignore)


### PR DESCRIPTION
By putting GoPath before SrcDirs we can prevent bad replacement of imports that have a prefix matching the GOPATH.  For example, if the GOPATH is "/go" and an import is something like "/go/src/golang.somewhere.com/thing" we don't want to replace the "go" in "golang.somewhere.com/thing". 